### PR TITLE
Fixed the Docker image build & associated instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM centurylink/ca-certs
+FROM alpine:3.6
+LABEL Description="Runs the web-rendezvous executable, listening on port 8080. See https://github.com/davidoram/web-rendezvous for usage"
+LABEL version="0.2"
 MAINTAINER David Oram
-EXPOSE 80
-
-WORKDIR /app
-
-# copy binary into image
-COPY web-rendezvous /app/
-
-ENTRYPOINT ["./web-rendezvous -port 80"]
+RUN apk add --update ca-certificates # Certificates for SSL
+ADD web-rendezvous /go/bin/web-rendezvous
+ENTRYPOINT /go/bin/web-rendezvous -port 8080
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -9,17 +9,12 @@ A webapp that allows network apps to lock and then signal one another by syncron
 ## Docker build
 
 
-Build a docker image:
+Build a docker image [credit](http://blog.dimroc.com/2015/08/20/cross-compiled-go-with-docker/):
 
 ```
-# Compile inside a golang docker container
-docker run --rm \
-           -it \
-           -v "$GOPATH":/gopath \
-           -v "$(pwd)":/main \
-           -e "GOPATH=/gopath" \
-           -w /main golang:1.8.1 \
-           sh -c 'CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags="-s" -o web-rendezvous'
+# Cross compile to Linux
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a --installsuffix cgo --ldflags="-s" -o web-rendezvous
+
 
 # Build the docker container with our binary
 docker build -t davidoram/web-rendezvous .


### PR DESCRIPTION
The previous Docker image didn't work, the new version v0.2 does.